### PR TITLE
add newlines to c output

### DIFF
--- a/pyoomph/c_output.py
+++ b/pyoomph/c_output.py
@@ -24,7 +24,7 @@ _T = TypeVar("_T")
 
 def _emit_label(name: str) -> str:
     # It's invalid c syntax to end a block with a label, (void)0 fixes
-    return f"{name}: (void)0;"
+    return f"{name}: (void)0;\n"
 
 
 class _FunctionEmitter:
@@ -46,32 +46,32 @@ class _FunctionEmitter:
     ) -> str:
         args_string = ",".join(map(self.emit_var, args))
         if result_var is None:
-            return f"{func}({args_string});"
-        return f"{self.emit_var(result_var)} = {func}({args_string});"
+            return f"{func}({args_string});\n"
+        return f"{self.emit_var(result_var)} = {func}({args_string});\n"
 
     def emit_body(self, body: List[ir.Instruction]) -> str:
         return "\n\t".join(map(self.emit_instruction, body))
 
     def emit_instruction(self, ins: ir.Instruction) -> str:
         if isinstance(ins, ir.StringConstant):
-            return f"{self.emit_var(ins.result)} = {self.file_emitter.emit_string(ins.value)}; {self.incref_var(ins.result)};"
+            return f"{self.emit_var(ins.result)} = {self.file_emitter.emit_string(ins.value)}; {self.incref_var(ins.result)};\n"
 
         if isinstance(ins, ir.IntConstant):
-            return f"{self.emit_var(ins.result)} = {ins.value}LL;"
+            return f"{self.emit_var(ins.result)} = {ins.value}LL;\n"
 
         if isinstance(ins, ir.FloatConstant):
-            return f"{self.emit_var(ins.result)} = {ins.value};"
+            return f"{self.emit_var(ins.result)} = {ins.value};\n"
 
         if isinstance(ins, ir.VarCpy):
-            return f"{self.emit_var(ins.dest)} = {self.emit_var(ins.source)};"
+            return f"{self.emit_var(ins.dest)} = {self.emit_var(ins.source)};\n"
 
         if isinstance(ins, ir.IncRef):
-            return self.incref_var(ins.var) + ";"
+            return self.incref_var(ins.var) + ";\n"
 
         if isinstance(ins, ir.DecRef):
             return (
                 self.file_emitter.emit_decref(self.emit_var(ins.var), ins.var.type)
-                + ";"
+                + ";\n"
             )
 
         if isinstance(ins, ir.CallFunction):
@@ -93,17 +93,17 @@ class _FunctionEmitter:
 
         if isinstance(ins, ir.Return):
             if ins.value is not None:
-                return f"{self.incref_var(ins.value)}; retval = {self.emit_var(ins.value)}; goto out;"
+                return f"{self.incref_var(ins.value)}; retval = {self.emit_var(ins.value)}; goto out;\n"
             return "goto out;"
 
         if isinstance(ins, ir.GetAttribute):
-            return f"{self.emit_var(ins.result)} = {self.emit_var(ins.obj)}->memb_{ins.attribute};"
+            return f"{self.emit_var(ins.result)} = {self.emit_var(ins.obj)}->memb_{ins.attribute};\n"
 
         if isinstance(ins, ir.SetAttribute):
-            return f"{self.emit_var(ins.obj)}->memb_{ins.attribute} = {self.emit_var(ins.value)};"
+            return f"{self.emit_var(ins.obj)}->memb_{ins.attribute} = {self.emit_var(ins.value)};\n"
 
         if isinstance(ins, ir.PointersEqual):
-            return f"{self.emit_var(ins.result)} = ({self.emit_var(ins.lhs)} == {self.emit_var(ins.rhs)});"
+            return f"{self.emit_var(ins.result)} = ({self.emit_var(ins.lhs)} == {self.emit_var(ins.rhs)});\n"
 
         if isinstance(ins, ir.If):
             then = self.emit_body(ins.then)
@@ -133,16 +133,16 @@ class _FunctionEmitter:
 
         if isinstance(ins, ir.Continue):
             # Can't use C's continue because continue must emit_funcdef condition
-            return f"goto {ins.loop_id};"
+            return f"goto {ins.loop_id};\n"
 
         if isinstance(ins, ir.Break):
-            return "break;"
+            return "break;\n"
 
         if isinstance(ins, ir.InstantiateUnion):
             assert isinstance(ins.result.type, ir.UnionType)
             assert ins.result.type.type_members is not None
             membernum = ins.result.type.type_members.index(ins.value.type)
-            return "%s = (%s){ .val = { .item%d = %s }, .membernum = %d };" % (
+            return "%s = (%s){ .val = { .item%d = %s }, .membernum = %d };\n" % (
                 self.emit_var(ins.result),
                 self.file_emitter.emit_type(ins.result.type),
                 membernum,
@@ -151,7 +151,7 @@ class _FunctionEmitter:
             )
 
         if isinstance(ins, ir.Null):
-            return self.emit_var(ins.result) + ".isnull = true;"
+            return self.emit_var(ins.result) + ".isnull = true;\n"
 
         if isinstance(ins, ir.GetFromUnion):
             assert isinstance(ins.union.type, ir.UnionType)
@@ -225,7 +225,7 @@ class _FunctionEmitter:
 
         body_instructions = self.emit_body(funcdef.body)
         decrefs = "".join(
-            self.file_emitter.emit_decref(self.emit_var(var), var.type) + ";"
+            self.file_emitter.emit_decref(self.emit_var(var), var.type) + ";\n"
             for var in reversed(self.need_decref)
         )
 
@@ -237,9 +237,9 @@ class _FunctionEmitter:
 
         if functype.returntype is not None:
             self.before_body += (
-                f"{self.file_emitter.emit_type(functype.returntype)} retval;"
+                f"{self.file_emitter.emit_type(functype.returntype)} retval;\n"
             )
-            self.after_body += "return retval;"
+            self.after_body += "return retval;\n"
 
         argnames = [self.emit_var(var) for var in funcdef.argvars]
         self.file_emitter.define_function(
@@ -520,7 +520,7 @@ class _FileEmitter:
             function_name,
             (", ".join(arg_decls) or "void"),
         )
-        self.function_decls += declaration + ";"
+        self.function_decls += declaration + ";\n"
         self.function_defs += declaration + "{" + body + "}"
 
     def get_var_name(self) -> str:
@@ -677,7 +677,7 @@ class _FileEmitter:
 
         elif isinstance(top_declaration, ir.ClassDef):
             struct_members = "".join(
-                f"{self.emit_type(the_type)} memb_{name};\n\t"
+                f"{self.emit_type(the_type)} memb_{name};\n"
                 for the_type, name in top_declaration.type.members
             )
             constructor_args = ",".join(

--- a/pyoomph/c_output.py
+++ b/pyoomph/c_output.py
@@ -94,7 +94,7 @@ class _FunctionEmitter:
         if isinstance(ins, ir.Return):
             if ins.value is not None:
                 return f"{self.incref_var(ins.value)}; retval = {self.emit_var(ins.value)}; goto out;\n"
-            return "goto out;"
+            return "goto out;\n"
 
         if isinstance(ins, ir.GetAttribute):
             return f"{self.emit_var(ins.result)} = {self.emit_var(ins.obj)}->memb_{ins.attribute};\n"


### PR DESCRIPTION
The C code is not human-readable, without `indent .oomph-cache/filename.c`, but the compiler error messages are unreadable when a source line they print is 1000 characters long.