### PR TITLE
Type files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Docs:
 Known bugs:
 - ref cycles are not prevented or garbage collected
 - self-hosted compiler (very wip) doesn't add `\n` to end of code
+    as specified in syntax docs
+- The `export` keyword does nothing, and all symbols are visible
 
 Missing features:
 - `==` for unions

--- a/pyoomph/__main__.py
+++ b/pyoomph/__main__.py
@@ -140,9 +140,9 @@ def main() -> None:
         if compiler_args.verbose:
             print("Creating C code:", unit.source_path)
         unit.create_c_code()
-    session.write_everything(project_root / "builtins.oomph")
 
-    command = get_c_compiler_command(session.get_c_paths(), exe_path)
+    c_paths = session.write_everything(project_root / "builtins.oomph")
+    command = get_c_compiler_command(c_paths, exe_path)
 
     result = run(command, compiler_args.verbose)
     if result != 0:

--- a/pyoomph/__main__.py
+++ b/pyoomph/__main__.py
@@ -104,8 +104,8 @@ def main() -> None:
             for top_declaration in unit.ast
             if isinstance(top_declaration, ast.Import)
         ]
-        #        if source_path != project_root / "builtins.oomph":
-        #            deps.append(project_root / "builtins.oomph")
+        if source_path != project_root / "builtins.oomph":
+            deps.append(project_root / "builtins.oomph")
         dependencies[unit.source_path] = deps
         todo_list.extend(deps)
 

--- a/pyoomph/__main__.py
+++ b/pyoomph/__main__.py
@@ -140,7 +140,7 @@ def main() -> None:
         if compiler_args.verbose:
             print("Creating C code:", unit.source_path)
         unit.create_c_code()
-    session.write_everything()
+    session.write_everything(project_root / "builtins.oomph")
 
     command = get_c_compiler_command(session.get_c_paths(), exe_path)
 

--- a/pyoomph/__main__.py
+++ b/pyoomph/__main__.py
@@ -28,7 +28,7 @@ class CompilationUnit:
             source_code, self.source_path, project_root / "stdlib"
         )
 
-    def create_c_code(self, exports: List[ir.Export]) -> None:
+    def create_c_code(self, exports: List[ir.Symbol]) -> None:
         try:
             ir = ast2ir.convert_program(self.ast, self.source_path, exports)
             self.session.create_c_code(ir, self.source_path)
@@ -139,7 +139,7 @@ def main() -> None:
     for unit in compilation_order:
         if compiler_args.verbose:
             print("Creating C code:", unit.source_path)
-        unit.create_c_code(session.exports)
+        unit.create_c_code(session.symbols)
 
     c_paths = session.write_everything(project_root / "builtins.oomph")
     command = get_c_compiler_command(c_paths, exe_path)

--- a/pyoomph/__main__.py
+++ b/pyoomph/__main__.py
@@ -43,24 +43,18 @@ class CompilationUnit:
             source_code, self.source_path, project_root / "stdlib"
         )
 
-    def create_c_and_h_files(
-        self,
-        headers: List[str],
-    ) -> None:
+    def create_c_and_h_files(self) -> None:
         try:
             ir = ast2ir.convert_program(
                 self.ast, self.source_path, self.session.exports
             )
-            c, h = self.session.create_c_code(ir, self.source_path, headers)
+            self.session.create_c_code(ir, self.source_path, self.c_path, self.h_path)
         except Exception:
             traceback.print_exc()
             print(
                 f"\nThis happened while compiling {self.source_path}", file=sys.stderr
             )
             sys.exit(1)
-
-        self.c_path.write_text(c, encoding="utf-8")
-        self.h_path.write_text(h, encoding="utf-8")
 
 
 def get_c_compiler_command(
@@ -162,11 +156,9 @@ def main() -> None:
     for index, unit in enumerate(compilation_order):
         if compiler_args.verbose:
             print("Creating c and h files:", unit.source_path)
-        already_compiled = compilation_order[:index]
-        unit.create_c_and_h_files([unit.h_path.name for unit in already_compiled])
+        unit.create_c_and_h_files()
 
-    command = get_c_compiler_command(
-        [unit.c_path for unit in all_compilation_units], exe_path
+    command = get_c_compiler_command(session.c_paths, exe_path
     )
 
     result = run(command, compiler_args.verbose)

--- a/pyoomph/__main__.py
+++ b/pyoomph/__main__.py
@@ -9,7 +9,7 @@ import sys
 import traceback
 from typing import Dict, List
 
-from pyoomph import ast, ast2ir, c_output, parser
+from pyoomph import ast, ast2ir, c_output, ir, parser
 
 python_code_dir = pathlib.Path(__file__).absolute().parent
 project_root = python_code_dir.parent
@@ -28,9 +28,9 @@ class CompilationUnit:
             source_code, self.source_path, project_root / "stdlib"
         )
 
-    def create_c_code(self) -> None:
+    def create_c_code(self, exports: List[ir.Export]) -> None:
         try:
-            ir = ast2ir.convert_program(self.ast, self.source_path, [])
+            ir = ast2ir.convert_program(self.ast, self.source_path, exports)
             self.session.create_c_code(ir, self.source_path)
         except Exception:
             traceback.print_exc()
@@ -139,7 +139,7 @@ def main() -> None:
     for unit in compilation_order:
         if compiler_args.verbose:
             print("Creating C code:", unit.source_path)
-        unit.create_c_code()
+        unit.create_c_code(session.exports)
 
     c_paths = session.write_everything(project_root / "builtins.oomph")
     command = get_c_compiler_command(c_paths, exe_path)

--- a/pyoomph/ast2ir.py
+++ b/pyoomph/ast2ir.py
@@ -783,8 +783,7 @@ class _FileConverter:
 
             typed_method_defs: List[ir.ToplevelDeclaration] = []
             if "equals" not in (method.name for method in top_declaration.body):
-                equals_def = self._create_pointers_equal_method(classtype)
-                typed_method_defs.append(equals_def)
+                typed_method_defs.append(self._create_pointers_equal_method(classtype))
 
             for method_def in top_declaration.body:
                 typed_def = self._do_func_or_method_def_pass2(method_def, classtype)
@@ -795,8 +794,7 @@ class _FileConverter:
                 self.exports.append(
                     ir.Export(self.path, top_declaration.name, classtype)
                 )
-            mypy_sucks: ir.ToplevelDeclaration = ir.TypeDef(classtype)
-            return [mypy_sucks] + typed_method_defs
+            return typed_method_defs
 
         if isinstance(top_declaration, ast.UnionDef):
             union_type = self._types[top_declaration.name]
@@ -807,7 +805,7 @@ class _FileConverter:
                 )
 
             equals = self._create_union_equals_method(union_type)
-            return [ir.TypeDef(union_type), equals]
+            return [equals]
 
         raise NotImplementedError(top_declaration)
 

--- a/pyoomph/c_output.py
+++ b/pyoomph/c_output.py
@@ -332,6 +332,11 @@ _generic_c_codes = {
         int64_t meth_%(type_cname)s_length(struct class_%(type_cname)s *self);
         struct class_Str *meth_%(type_cname)s_to_string(struct class_%(type_cname)s *self);
         struct class_%(type_cname)s *meth_%(type_cname)s_reversed(const struct class_%(type_cname)s *self);
+
+        // Kind of a weird hack
+        #if %(itemtype_is_string)s
+        #define meth_%(type_cname)s_join meth_List_Str_join
+        #endif
         """,
         "function_defs": """
         struct class_%(type_cname)s *ctor_%(type_cname)s(void)
@@ -625,6 +630,7 @@ class _FilePair:
                 "type_string": self.emit_string(the_type.name),
                 "itemtype": self.emit_type(itemtype),
                 "itemtype_cname": self.session.get_type_c_name(itemtype),
+                "itemtype_is_string": int(itemtype == STRING),
                 # TODO: replace with macros
                 "incref_val": self.session.emit_incref("val", itemtype),
                 "decref_val": self.session.emit_decref("val", itemtype),

--- a/pyoomph/c_output.py
+++ b/pyoomph/c_output.py
@@ -519,7 +519,14 @@ class _FilePair:
                 self.includes.add(defining_file_pair)
             type_id = defining_file_pair.id
 
-        if the_type.refcounted and not isinstance(the_type, UnionType):
+        if (
+            the_type.refcounted
+            and not isinstance(the_type, UnionType)
+            and not (
+                the_type.generic_origin is not None
+                and the_type.generic_origin.generic is OPTIONAL
+            )
+        ):
             return f"struct class_{type_id} *"
         return f"struct class_{type_id}"
 

--- a/pyoomph/c_output.py
+++ b/pyoomph/c_output.py
@@ -554,9 +554,9 @@ class _FilePair:
     def emit_var(self, var: ir.Variable) -> str:
         assert not isinstance(var, ir.LocalVariable)
 
-        for export in self.session.exports:
-            if export.value == var:
-                pair = self.session.source_path_to_file_pair[export.path]
+        for symbol in self.session.symbols:
+            if symbol.value == var:
+                pair = self.session.source_path_to_file_pair[symbol.path]
                 if pair is not self:
                     self.c_includes.add(pair)
                     self.h_includes.add(pair)
@@ -565,7 +565,7 @@ class _FilePair:
             return self.variable_names[var]
         except KeyError:
             assert isinstance(var.type, FunctionType)
-            if isinstance(var, ir.ExportVariable) and var.name == "main":
+            if isinstance(var, ir.FileVariable) and var.name == "main":
                 c_name = "oomph_main"
             elif var.name in {
                 "__List_Str_join",
@@ -825,7 +825,7 @@ def _create_id(readable_part: str, identifying_part: str) -> str:
 class Session:
     def __init__(self, compilation_dir: pathlib.Path) -> None:
         self.compilation_dir = compilation_dir
-        self.exports: List[ir.Export] = []
+        self.symbols: List[ir.Symbol] = []
         self._type_to_file_pair: Dict[Type, _FilePair] = {}
         self.source_path_to_file_pair: Dict[pathlib.Path, _FilePair] = {}
 

--- a/pyoomph/c_output.py
+++ b/pyoomph/c_output.py
@@ -814,8 +814,7 @@ class Session:
 
     def get_file_pair_for_type(self, the_type: Type) -> _FilePair:
         if the_type not in self._type_to_file_pair:
-            # FIXME: Optional[Foo] when two files define different Foo classes
-            identifying = str(the_type.definition_path) + the_type.name
+            identifying = the_type.get_id_string()
             pair = _FilePair(self, _create_id(the_type.name, identifying))
             self._type_to_file_pair[the_type] = pair
             pair.define_type(the_type)

--- a/pyoomph/c_output.py
+++ b/pyoomph/c_output.py
@@ -600,13 +600,6 @@ class _FilePair:
             c_name = self.id + "_" + var.name
         return c_name
 
-    def emit_method(self, the_type: Type, method_name: str) -> str:
-        if the_type in builtin_types.values():
-            return f"meth_{the_type.name}_{method_name}"
-
-        defining_file_pair = self.session.get_file_pair_for_type(the_type)
-        return f"meth_{defining_file_pair.id}_{method_name}"
-
     def define_function(
         self, function_name: str, the_type: FunctionType, argnames: List[str], body: str
     ) -> None:

--- a/pyoomph/c_output.py
+++ b/pyoomph/c_output.py
@@ -28,6 +28,11 @@ def _emit_label(name: str) -> str:
     return f"{name}: (void)0;\n"
 
 
+def _create_id(readable_part: str, identifying_part: str) -> str:
+    md5 = hashlib.md5(identifying_part.encode("utf-8")).hexdigest()
+    return re.sub(r"[^A-Za-z0-9]", "_", readable_part) + "_" + md5[:10]
+
+
 class _FunctionEmitter:
     def __init__(self, file_pair: _FilePair) -> None:
         self.file_pair = file_pair
@@ -620,9 +625,7 @@ class _FilePair:
 
     def emit_string(self, value: str) -> str:
         if value not in self.strings:
-            self.strings[value] = (
-                f"string{len(self.strings)}_" + re.sub(r"[^A-Za-z0-9]", "", value)[:30]
-            )
+            self.strings[value] = _create_id(f"string{len(self.strings)}_" + value, value)
 
             # String constants consist of int64_t refcount set to -1,
             # followed by utf8, followed by zero byte
@@ -814,11 +817,6 @@ class _FilePair:
 
         else:
             raise NotImplementedError(top_declaration)
-
-
-def _create_id(readable_part: str, identifying_part: str) -> str:
-    md5 = hashlib.md5(identifying_part.encode("utf-8")).hexdigest()
-    return re.sub(r"[^A-Za-z0-9]", "_", readable_part) + "_" + md5[:10]
 
 
 # This state is shared between different files

--- a/pyoomph/ir.py
+++ b/pyoomph/ir.py
@@ -36,9 +36,6 @@ class LocalVariable:
         return "<LocalVariable %#x: %s>" % (id(self), self.type.name)
 
 
-# Currently these are always functions. These would be called "global
-# variables" in Python, but that's confusing, because they are less global
-# than ExportVariables.
 @dataclass(eq=False)
 class FileVariable:
     name: str

--- a/pyoomph/ir.py
+++ b/pyoomph/ir.py
@@ -337,12 +337,6 @@ class MethodDef(ToplevelDeclaration):
     body: List[Instruction]
 
 
-# Class or union
-@dataclass(eq=False)
-class TypeDef(ToplevelDeclaration):
-    type: Type
-
-
 @dataclass(eq=False)
 class Export:
     path: pathlib.Path

--- a/pyoomph/ir.py
+++ b/pyoomph/ir.py
@@ -40,17 +40,13 @@ class LocalVariable:
 # variables" in Python, but that's confusing, because they are less global
 # than ExportVariables.
 @dataclass(eq=False)
-class ThisFileVariable:
+class FileVariable:
     name: str
     type: Type
+    source_path: pathlib.Path
 
 
-@dataclass(eq=False)
-class ExportVariable:
-    name: str
-    type: Type
-
-
+# TODO: combine BuiltinVariable and SpecialVariable?
 @dataclass(eq=False)
 class BuiltinVariable:
     name: str
@@ -63,9 +59,7 @@ class SpecialVariable:
     type: Type
 
 
-Variable = Union[
-    LocalVariable, ThisFileVariable, ExportVariable, BuiltinVariable, SpecialVariable
-]
+Variable = Union[LocalVariable, FileVariable, BuiltinVariable, SpecialVariable]
 
 
 builtin_variables = {
@@ -324,7 +318,7 @@ class ToplevelDeclaration:
 
 @dataclass(eq=False)
 class FuncDef(ToplevelDeclaration):
-    var: Union[ThisFileVariable, ExportVariable]
+    var: FileVariable
     argvars: List[LocalVariable]
     body: List[Instruction]
 
@@ -337,8 +331,9 @@ class MethodDef(ToplevelDeclaration):
     body: List[Instruction]
 
 
+# Anything that might need to be shared between different .c files
 @dataclass(eq=False)
-class Export:
+class Symbol:
     path: pathlib.Path
     name: str
-    value: Union[ExportVariable, Type]  # Type includes UnionType
+    value: Union[FileVariable, Type]  # Type includes UnionType

--- a/pyoomph/types.py
+++ b/pyoomph/types.py
@@ -27,6 +27,13 @@ class Type:
         self.constructor_argtypes: Optional[List[Type]] = None
         self.generic_origin: Optional[GenericSource] = None
 
+    def get_id_string(self):
+        result = self.name + str(self.definition_path)
+        if self.generic_origin is not None:
+            result += self.generic_origin.generic.name
+            result += self.generic_origin.arg.get_id_string()
+        return result
+
     def __repr__(self) -> str:
         return f"<{type(self).__name__}: {self.name}>"
 

--- a/pyoomph/types.py
+++ b/pyoomph/types.py
@@ -57,7 +57,7 @@ class UnionType(Type):
     def set_type_members(self, type_members: List[Type]) -> None:
         assert len(type_members) >= 2
         assert len(type_members) == len(set(type_members))  # no duplicates
-        assert all(t.refcounted for t in type_members)  # TODO
+        assert all(t.refcounted for t in type_members)  # TODO: get rid of this assert
         assert self.type_members is None
         self.type_members = type_members
 

--- a/pyoomph/types.py
+++ b/pyoomph/types.py
@@ -27,7 +27,7 @@ class Type:
         self.constructor_argtypes: Optional[List[Type]] = None
         self.generic_origin: Optional[GenericSource] = None
 
-    def get_id_string(self):
+    def get_id_string(self) -> str:
         result = self.name + str(self.definition_path)
         if self.generic_origin is not None:
             result += self.generic_origin.generic.name


### PR DESCRIPTION
Separate file for each type.

How I ended up doing this:
- I want to make `Optional[Str]` into a `Union`.
- Because you can write `Optional[Str]` anywhere, any file could define the `Optional[Str]` union. To avoid C compiler errors, it is important that only one file defines it.
- Because there's no good way to figure out which file should define the union, we might as well make it a separate file, and while we're at it, make all types be in separate files.

This PR ignores the meaning of `export` and makes all symbols visible. That can be changed later.