### PR TITLE
Use goto in generated c code

### DIFF
--- a/pyoomph/c_output.py
+++ b/pyoomph/c_output.py
@@ -115,17 +115,6 @@ class _FunctionEmitter:
         if isinstance(ins, ir.PointersEqual):
             return f"{self.emit_var(ins.result)} = ({self.emit_var(ins.lhs)} == {self.emit_var(ins.rhs)});\n"
 
-        if isinstance(ins, ir.If):
-            then = self.emit_body(ins.then)
-            otherwise = self.emit_body(ins.otherwise)
-            return f"""
-            if ({self.emit_var(ins.condition)}) {{
-                {then}
-            }} else {{
-                {otherwise}
-            }}
-            """
-
         if isinstance(ins, ir.Loop):
             cond_code = self.emit_body(ins.cond_code)
             body = self.emit_body(ins.body)

--- a/pyoomph/c_output.py
+++ b/pyoomph/c_output.py
@@ -115,28 +115,6 @@ class _FunctionEmitter:
         if isinstance(ins, ir.PointersEqual):
             return f"{self.emit_var(ins.result)} = ({self.emit_var(ins.lhs)} == {self.emit_var(ins.rhs)});\n"
 
-        if isinstance(ins, ir.Loop):
-            cond_code = self.emit_body(ins.cond_code)
-            body = self.emit_body(ins.body)
-            incr = self.emit_body(ins.incr)
-            return f"""
-            while(1) {{
-                {cond_code}
-                if (!{self.emit_var(ins.cond)})
-                    break;
-                {body}
-                {_emit_label(ins.loop_id + "_continue")}
-                {incr}
-            }}
-            {_emit_label(ins.loop_id + "_break")}
-            """
-
-        if isinstance(ins, ir.Continue):
-            return f"goto {ins.loop_id}_continue;\n"
-
-        if isinstance(ins, ir.Break):
-            return f"goto {ins.loop_id}_break;\n"
-
         if isinstance(ins, ir.InstantiateUnion):
             assert isinstance(ins.result.type, ir.UnionType)
             assert ins.result.type.type_members is not None

--- a/pyoomph/ir.py
+++ b/pyoomph/ir.py
@@ -257,16 +257,6 @@ class Return(Instruction):
 
 
 @dataclass(eq=False)
-class If(Instruction):
-    condition: LocalVariable
-    then: List[Instruction]
-    otherwise: List[Instruction]
-
-    def __post_init__(self) -> None:
-        assert self.condition.type == BOOL
-
-
-@dataclass(eq=False)
 class Loop(Instruction):
     loop_id: str
     cond_code: List[Instruction]

--- a/pyoomph/ir.py
+++ b/pyoomph/ir.py
@@ -242,30 +242,8 @@ class IsNull(Instruction):
 
 
 @dataclass(eq=False)
-class Continue(Instruction):
-    loop_id: str
-
-
-@dataclass(eq=False)
-class Break(Instruction):
-    loop_id: str
-
-
-@dataclass(eq=False)
 class Return(Instruction):
     value: Optional[LocalVariable]
-
-
-@dataclass(eq=False)
-class Loop(Instruction):
-    loop_id: str
-    cond_code: List[Instruction]
-    cond: LocalVariable
-    incr: List[Instruction]
-    body: List[Instruction]
-
-    def __post_init__(self) -> None:
-        assert self.cond.type == BOOL
 
 
 @dataclass(eq=False, repr=False)

--- a/pyoomph/ir.py
+++ b/pyoomph/ir.py
@@ -290,11 +290,12 @@ class GetFromUnion(Instruction):
     union: LocalVariable
 
 
-# TODO: replace with nested Ifs or something like that?
+# Check is it possible to call GetFromUnion with result var of given member type
 @dataclass(eq=False)
-class Switch(Instruction):
+class UnionMemberCheck(Instruction):
+    result: LocalVariable
     union: LocalVariable
-    cases: Dict[Type, List[Instruction]]
+    member_type: Type
 
 
 @dataclass(eq=False)

--- a/pyoomph/ir.py
+++ b/pyoomph/ir.py
@@ -278,6 +278,20 @@ class Loop(Instruction):
         assert self.cond.type == BOOL
 
 
+@dataclass(eq=False, repr=False)
+class GotoLabel(Instruction):
+    pass
+
+
+@dataclass(eq=False)
+class Goto(Instruction):
+    label: GotoLabel
+    cond: Union[BuiltinVariable, LocalVariable]  # can be set to builtin true
+
+    def __post_init__(self) -> None:
+        assert self.cond.type == BOOL
+
+
 # Runtime error if trying to get wrong union member
 # think of it as VarCpy for unions
 @dataclass(eq=False)


### PR DESCRIPTION
Why:
- Later, it will be easier to check whether a local variable can be undefined: just loop backwards along a flat list of instructions and follow `Goto` instructions, instead of dealing with each of `Switch`,`If`,`Loop` separately
- Less `c_output` code, giving the illusion of not depending very heavily on C specifically
- Self-hosted compiler is already doing this