### PR TITLE
trying to make string concats faster

### DIFF
--- a/lib/oomph.h
+++ b/lib/oomph.h
@@ -16,7 +16,8 @@
 struct StringBuf {
 	REFCOUNT_HEADER
 	const char *data;
-	bool malloced;    // can you e.g. do free(buf->data)
+	bool malloced;  // can you e.g. do free(buf->data)
+	size_t len;     // strings don't use StringBuf beyond this, but more space may be malloced
 	char flex[];    // allows allocating StringBuf and data at once, not used otherwise
 };
 

--- a/lib/oomph.h
+++ b/lib/oomph.h
@@ -15,7 +15,7 @@
 // Can be shared by multiple string for efficient substrings
 struct StringBuf {
 	REFCOUNT_HEADER
-	const char *data;
+	char *data;
 	bool malloced;  // can you e.g. do free(buf->data)
 	size_t len;     // strings don't use StringBuf beyond this, but more space may be malloced
 	char flex[];    // allows allocating StringBuf and data at once, not used otherwise

--- a/lib/string.c
+++ b/lib/string.c
@@ -1,6 +1,5 @@
 #include "oomph.h"
 #include <assert.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/lib/string.c
+++ b/lib/string.c
@@ -67,8 +67,9 @@ char *string_to_cstr(struct class_Str s)
 struct class_Str oomph_string_concat(struct class_Str str1, struct class_Str str2)
 {
 	assert(str1.offset + str1.nbytes <= str1.buf->len);
-	if (str1.offset + str1.nbytes == str1.buf->len) {
+	if (str1.offset + str1.nbytes == str1.buf->len && str1.offset <= str1.nbytes) {
 		// We can grow the buffer to fit str2 too
+		// Don't do this when str1 is tiny part at end of buf, see tests/huge_malloc_bug.oomph
 		size_t newlen = str1.buf->len + str2.nbytes;
 		if (str1.buf->malloced) {
 			if (how_much_to_allocate(newlen) > how_much_to_allocate(str1.buf->len)) {

--- a/lib/string.c
+++ b/lib/string.c
@@ -31,7 +31,7 @@ void string_buf_destructor(void *ptr)
 {
 	struct StringBuf *buf = ptr;
 	if (buf->malloced)
-		free((char*)buf->data);
+		free(buf->data);
 	free(buf);
 }
 

--- a/lib/string.c
+++ b/lib/string.c
@@ -43,7 +43,7 @@ bool meth_Str_equals(struct class_Str a, struct class_Str b)
 struct class_Str data_to_string(const char *data, size_t len)
 {
 	struct StringBuf *buf = alloc_buf(len);
-	memcpy(buf->flex, data, len);
+	memcpy(buf->data, data, len);
 	return (struct class_Str){ .buf = buf, .nbytes = len, .offset = 0 };
 }
 
@@ -91,8 +91,8 @@ struct class_Str oomph_string_concat(struct class_Str str1, struct class_Str str
 	}
 
 	struct StringBuf *buf = alloc_buf(str1.nbytes + str2.nbytes);
-	memcpy(buf->flex, string_data(str1), str1.nbytes);
-	memcpy(buf->flex + str1.nbytes, string_data(str2), str2.nbytes);
+	memcpy(buf->data, string_data(str1), str1.nbytes);
+	memcpy(buf->data + str1.nbytes, string_data(str2), str2.nbytes);
 	return (struct class_Str){ .buf = buf, .nbytes = str1.nbytes + str2.nbytes, .offset = 0 };
 }
 
@@ -101,8 +101,8 @@ void oomph_string_concat_inplace_cstr(struct class_Str *res, const char *suf)
 	// TODO: optimize?
 	struct class_Str old = *res;
 	struct StringBuf *buf = alloc_buf(old.nbytes + strlen(suf));
-	memcpy(buf->flex, string_data(old), old.nbytes);
-	memcpy(buf->flex + old.nbytes, suf, strlen(suf));
+	memcpy(buf->data, string_data(old), old.nbytes);
+	memcpy(buf->data + old.nbytes, suf, strlen(suf));
 	string_decref(*res);
 	*res = (struct class_Str){ .buf = buf, .nbytes = old.nbytes + strlen(suf), .offset = 0 };
 }

--- a/lib/string.c
+++ b/lib/string.c
@@ -64,31 +64,22 @@ char *string_to_cstr(struct class_Str s)
 	return res;
 }
 
-#define likely(x)   __builtin_expect(!!(x), 1)
-#define unlikely(x) __builtin_expect(!!(x), 0)
-//#define likely(x)   (x)
-//#define unlikely(x) (x)
-
 struct class_Str oomph_string_concat(struct class_Str str1, struct class_Str str2)
 {
 	assert(str1.offset + str1.nbytes <= str1.buf->len);
-	if (likely(str1.offset + str1.nbytes == str1.buf->len)) {
+	if (str1.offset + str1.nbytes == str1.buf->len) {
 		// We can grow the buffer to fit str2 too
 		size_t newlen = str1.buf->len + str2.nbytes;
-		if (likely(str1.buf->malloced)) {
-			if (unlikely(how_much_to_allocate(newlen) > how_much_to_allocate(str1.buf->len))) {
+		if (str1.buf->malloced) {
+			if (how_much_to_allocate(newlen) > how_much_to_allocate(str1.buf->len)) {
 				str1.buf->data = realloc(str1.buf->data, how_much_to_allocate(newlen));
 				assert(str1.buf->data);
-//				printf("fast realloc\n");
-			} else {
-//				printf("fast no alloc\n");
 			}
 		} else {
 			char *newdata = malloc(how_much_to_allocate(newlen));
 			assert(newdata);
 			memcpy(newdata, str1.buf->data, str1.buf->len);
 			str1.buf->data = newdata;
-//			printf("fast malloc\n");
 		}
 		str1.buf->malloced = true;
 		memcpy(str1.buf->data + str1.buf->len, string_data(str2), str2.nbytes);
@@ -98,7 +89,6 @@ struct class_Str oomph_string_concat(struct class_Str str1, struct class_Str str
 		return (struct class_Str){ .buf = str1.buf, .nbytes = str1.nbytes + str2.nbytes, .offset = str1.offset };
 	}
 
-//	printf("slow\n");
 	struct StringBuf *buf = alloc_buf(str1.nbytes + str2.nbytes);
 	memcpy(buf->flex, string_data(str1), str1.nbytes);
 	memcpy(buf->flex + str1.nbytes, string_data(str2), str2.nbytes);

--- a/pyoomph/c_output.py
+++ b/pyoomph/c_output.py
@@ -380,6 +380,7 @@ class _FilePair:
                 .refcount = -1,
                 .data = (char[]){{ {array_content or "0"} }},
                 .malloced = false,
+                .len = {len(value.encode("utf-8"))},
             }};
             static {self.emit_type(STRING)} {self.strings[value]} = {{
                 .buf = &{self.strings[value]}_buf,

--- a/self_hosted/c_output.oomph
+++ b/self_hosted/c_output.oomph
@@ -403,6 +403,7 @@ class FilePair(
                 .refcount = -1,
                 .data = (char[])\{ {content_chars.join(",")} \},
                 .malloced = false,
+                .len = {value.get_utf8().length()},
             \};
             static struct class_Str {varname} = \{
                 .buf = &{varname}_buf,

--- a/tests/huge_malloc_bug.oomph
+++ b/tests/huge_malloc_bug.oomph
@@ -1,0 +1,7 @@
+export func main():
+    let part = "hello".repeat(500)
+    let string = part + part
+
+    # This should not allocate a huge amount of mem
+    for let i = 0; i < 1000000; i = i+1:
+        string = (string + part).remove_prefix(part)


### PR DESCRIPTION
Haven't tried profiling this (yet), but `time ./test --self-hosted` doesn't improve that much (`time ./test --self-hosted` goes `real 0m58,742s --> real 0m53,758s`)

- [x] make sure that repeatedly adding to end and removing from beginning doesn't alloc all available mem