### PR TITLE
don't use strings to reference to variables in ast

### DIFF
--- a/pyoomph/ast.py
+++ b/pyoomph/ast.py
@@ -42,14 +42,14 @@ class Statement:
 
 
 @dataclass(eq=False)
-class GetVar(Expression):
-    varname: str
+class Variable(Expression):
+    name: str
     lineno: Optional[int] = None
 
 
 @dataclass(eq=False)
 class SetVar(Statement):
-    varname: str
+    var: Variable
     value: Expression
 
 
@@ -136,7 +136,7 @@ class Call(Expression, Statement):
 
 @dataclass(eq=False)
 class Let(Statement):
-    varname: str
+    var: Variable
     value: Expression
 
 
@@ -176,7 +176,7 @@ class ForLoopHeader:
 
 @dataclass(eq=False)
 class ForeachLoopHeader:
-    varname: str
+    var: Variable
     list: Expression
 
 
@@ -195,7 +195,7 @@ class ListComprehension(Expression):
 @dataclass(eq=False)
 class Case:
     # None means 'case *'
-    type_and_varname: Optional[Tuple[Type, str]]
+    type_and_var: Optional[Tuple[Type, Variable]]
     body: List[Statement]
 
 
@@ -219,7 +219,7 @@ class Import(ToplevelDeclaration):
 @dataclass(eq=False)
 class FuncOrMethodDef(ToplevelDeclaration):
     name: str
-    args: List[Tuple[Type, str]]
+    args: List[Tuple[Type, Variable]]
     returntype: Optional[Type]
     body: List[Statement]
     export: bool = False  # never true for methods

--- a/self_hosted/ast.oomph
+++ b/self_hosted/ast.oomph
@@ -54,16 +54,22 @@ export typedef Statement = (
 # In ToplevelDeclaration, FuncOrMethodDef is always function definition
 export typedef ToplevelDeclaration = ClassDef | FuncOrMethodDef | Import | TypeDef
 
-export class TypeAndName(Type type, Str name, Location name_location)
+# Always use Variable when referring to variable. Several Variable objects may refer
+# to the same variable because the parser isn't responsible for figuring it out.
+export class Variable(Location location, Str name)
+
+# TODO: tuple
+export class TypeAndVar(Type type, Variable var)
+export class TypeAndName(Type type, Str name)
 
 # 'case *' means that type_and_varname is null
-export class Case(Location location, TypeAndName | null type_and_name, List[Statement] body)
+export class Case(Location location, TypeAndVar | null type_and_var, List[Statement] body)
 export class ConditionAndBody(Location location, Expression cond, List[Statement] body)
 
 export typedef LoopHeader = ForLoopHeader | ForeachLoopHeader
 # for init; cond; incr
 export class ForLoopHeader(Location keyword_location, List[Statement] init, Expression | null cond, List[Statement] incr)
-export class ForeachLoopHeader(Location keyword_location, Str varname, Expression list)
+export class ForeachLoopHeader(Location keyword_location, Variable var, Expression list)
 
 export class As(Location location, Expression expr, Type type, Bool as_not)
 export class BinaryOperator(Location location, Expression lhs, Str op, Expression rhs)
@@ -71,7 +77,7 @@ export class Call(Location location, Expression function, List[Expression] args)
 export class Constructor(Location location, Type type)
 export class FloatConstant(Location location, Str value)  # value not converted to float in case weirdness :D
 export class GetAttribute(Location attribute_location, Expression obj, Str attribute)
-export class GetVar(Location location, Str varname)
+export class GetVar(Variable var)  # TODO: delete?
 export class IntConstant(Location location, Int value)
 export class ListComprehension(LoopHeader loop_header, Expression value)
 export class ListLiteral(Location location, List[Expression] content)
@@ -84,17 +90,17 @@ export class UnaryOperator(Location location, Str op, Expression obj)
 export class Break(Location location)
 export class Continue(Location location)
 export class If(List[ConditionAndBody] ifs_and_elifs, List[Statement] else_block)
-export class Let(Location location, Str varname, Expression value)
+export class Let(Location location, Variable var, Expression value)
 export class Loop(LoopHeader loop_header, List[Statement] body)
 export class Pass(Location location)
 export class Return(Location location, Expression | null value)
 export class SetAttribute(Location attribute_location, Expression obj, Str attribute, Expression value)
-export class SetVar(Location location, Str varname, Expression value)
+export class SetVar(Location location, Variable var, Expression value)
 export class Switch(Location location, Expression union_obj, List[Case] cases)
 
 export class NoReturn(Location location)
 
-export class FuncOrMethodDef(Location location, Str name, List[TypeAndName] args, Type | NoReturn | null returntype, List[Statement] body)
+export class FuncOrMethodDef(Location location, Str name, List[TypeAndVar] args, Type | NoReturn | null returntype, List[Statement] body)
 export class ClassDef(Location location, Str name, List[TypeAndName] members, List[FuncOrMethodDef] body)
 export class Import(Location location, Str path, Str name)
 export class TypeDef(Location location, Str name, Type type)
@@ -121,7 +127,7 @@ export func locate_expression(Expression expression) -> Location:
         case GetAttribute expr:
             return locate_expression(expr.obj).combine(expr.attribute_location)
         case GetVar expr:
-            return expr.location
+            return expr.var.location
         case IntConstant expr:
             return expr.location
         case ListComprehension expr:

--- a/self_hosted/ast.oomph
+++ b/self_hosted/ast.oomph
@@ -28,7 +28,7 @@ export typedef Expression = (
     | Constructor
     | FloatConstant
     | GetAttribute
-    | GetVar
+    | Variable
     | IntConstant
     | ListComprehension
     | ListLiteral
@@ -77,7 +77,6 @@ export class Call(Location location, Expression function, List[Expression] args)
 export class Constructor(Location location, Type type)
 export class FloatConstant(Location location, Str value)  # value not converted to float in case weirdness :D
 export class GetAttribute(Location attribute_location, Expression obj, Str attribute)
-export class GetVar(Variable var)  # TODO: delete?
 export class IntConstant(Location location, Int value)
 export class ListComprehension(LoopHeader loop_header, Expression value)
 export class ListLiteral(Location location, List[Expression] content)
@@ -126,8 +125,8 @@ export func locate_expression(Expression expression) -> Location:
             return expr.location
         case GetAttribute expr:
             return locate_expression(expr.obj).combine(expr.attribute_location)
-        case GetVar expr:
-            return expr.var.location
+        case Variable expr:
+            return expr.location
         case IntConstant expr:
             return expr.location
         case ListComprehension expr:

--- a/self_hosted/ast2ir.oomph
+++ b/self_hosted/ast2ir.oomph
@@ -344,10 +344,10 @@ class FunctionOrMethodConverter(
                     self_var, method.attribute, args, result_var, call.location
                 ))
 
-            case ast::GetVar ast_function:
-                if not self.variables.has_key(ast_function.var.name):
-                    ast_function.var.location.error("variable not found: {ast_function.var.name}")
-                let function = self.variables.get(ast_function.var.name)
+            case ast::Variable ast_function:
+                if not self.variables.has_key(ast_function.name):
+                    ast_function.location.error("variable not found: {ast_function.name}")
+                let function = self.variables.get(ast_function.name)
                 let functype = ir::var_type(function) as ir::FunctionType
 
                 switch functype.returntype:
@@ -358,21 +358,17 @@ class FunctionOrMethodConverter(
 
                 if function == self.builtins.visible_vars.get("print"):
                     if args.length() != 1:
-                        ast_function.var.location.error("print must be called with 1 argument")
+                        ast_function.location.error("print must be called with 1 argument")
                     args = [foreach arg of args: self.stringify(arg)]
                 else:
                     if function == self.builtins.visible_vars.get("assert"):
                         if args.length() != 1:
-                            ast_function.var.location.error("assert must be called with 1 argument")
+                            ast_function.location.error("assert must be called with 1 argument")
                         # Add path and line number args
-                        let loc = ast_function.var.location
+                        let loc = ast_function.location
                         args.push(self.do_expression(new ast::StringConstant(loc, loc.path)))
                         args.push(self.do_expression(new ast::IntConstant(loc, loc.lineno)))
-                    args = self.do_args(
-                        args,
-                        functype.argtypes,
-                        ast_function.var.location,
-                    )
+                    args = self.do_args(args, functype.argtypes, ast_function.location)
                 self.code.push(new ir::FunctionCall(function, args, result_var))
 
             case ast::Constructor constructor:
@@ -575,12 +571,14 @@ class FunctionOrMethodConverter(
                 # TODO: error?
                 return self.do_call(call, true) as not null
 
-            case ast::GetVar getvar:
+            case ast::Variable variable:
+                let var = variable   # TODO: this sucks
+
                 # Don't return the same variable, otherwise 'a = a' decrefs too much
                 # Also ensure we always return LocalVariable
-                if not self.variables.has_key(getvar.var.name):
-                    location.error("variable not found: {getvar.var.name}")
-                let old_var = self.variables.get(getvar.var.name)
+                if not self.variables.has_key(var.name):
+                    location.error("variable not found: {var.name}")
+                let old_var = self.variables.get(var.name)
                 let new_var = self.create_var(ir::var_type(old_var), location)
                 self.code.push(new ir::VarCpy(new_var, old_var))
                 self.code.push(new ir::IncRef(new_var))

--- a/self_hosted/ast2ir.oomph
+++ b/self_hosted/ast2ir.oomph
@@ -345,9 +345,9 @@ class FunctionOrMethodConverter(
                 ))
 
             case ast::GetVar ast_function:
-                if not self.variables.has_key(ast_function.varname):
-                    ast_function.location.error("variable not found: {ast_function.varname}")
-                let function = self.variables.get(ast_function.varname)
+                if not self.variables.has_key(ast_function.var.name):
+                    ast_function.var.location.error("variable not found: {ast_function.var.name}")
+                let function = self.variables.get(ast_function.var.name)
                 let functype = ir::var_type(function) as ir::FunctionType
 
                 switch functype.returntype:
@@ -358,20 +358,20 @@ class FunctionOrMethodConverter(
 
                 if function == self.builtins.visible_vars.get("print"):
                     if args.length() != 1:
-                        ast_function.location.error("print must be called with 1 argument")
+                        ast_function.var.location.error("print must be called with 1 argument")
                     args = [foreach arg of args: self.stringify(arg)]
                 else:
                     if function == self.builtins.visible_vars.get("assert"):
                         if args.length() != 1:
-                            ast_function.location.error("assert must be called with 1 argument")
+                            ast_function.var.location.error("assert must be called with 1 argument")
                         # Add path and line number args
-                        let loc = ast_function.location
+                        let loc = ast_function.var.location
                         args.push(self.do_expression(new ast::StringConstant(loc, loc.path)))
                         args.push(self.do_expression(new ast::IntConstant(loc, loc.lineno)))
                     args = self.do_args(
                         args,
                         functype.argtypes,
-                        ast_function.location,
+                        ast_function.var.location,
                     )
                 self.code.push(new ir::FunctionCall(function, args, result_var))
 
@@ -578,9 +578,9 @@ class FunctionOrMethodConverter(
             case ast::GetVar getvar:
                 # Don't return the same variable, otherwise 'a = a' decrefs too much
                 # Also ensure we always return LocalVariable
-                if not self.variables.has_key(getvar.varname):
-                    location.error("variable not found: {getvar.varname}")
-                let old_var = self.variables.get(getvar.varname)
+                if not self.variables.has_key(getvar.var.name):
+                    location.error("variable not found: {getvar.var.name}")
+                let old_var = self.variables.get(getvar.var.name)
                 let new_var = self.create_var(ir::var_type(old_var), location)
                 self.code.push(new ir::VarCpy(new_var, old_var))
                 self.code.push(new ir::IncRef(new_var))
@@ -677,12 +677,12 @@ class FunctionOrMethodConverter(
 
             case ast::Let leet:
                 # TODO: document the shadowing/replacing behaviour
-                self.variables.set(leet.varname, self.do_expression(leet.value))
+                self.variables.set(leet.var.name, self.do_expression(leet.value))
 
             case ast::SetVar setvar:
-                if not self.variables.has_key(setvar.varname):
-                    setvar.location.error("variable not found: {setvar.varname}")
-                let var = self.variables.get(setvar.varname) as ir::LocalVariable  # TODO: error
+                if not self.variables.has_key(setvar.var.name):
+                    setvar.location.error("variable not found: {setvar.var.name}")
+                let var = self.variables.get(setvar.var.name) as ir::LocalVariable  # TODO: error
                 let new_value_var = self.do_expression(setvar.value)
                 self.code.push(new ir::DecRef(var))
                 self.code.push(
@@ -784,8 +784,8 @@ class FunctionOrMethodConverter(
                 if header.init.length() == 1:
                     switch header.init.first():
                         case ast::Let leet:
-                            if self.variables.has_key(leet.varname):
-                                self.variables.delete(leet.varname)
+                            if self.variables.has_key(leet.var.name):
+                                self.variables.delete(leet.var.name)
                         case *:
                             pass
 
@@ -802,13 +802,13 @@ class FunctionOrMethodConverter(
                     let label = self.create_goto_label()
                     cases.push(label)
 
-                    if chase.type_and_name == null:
+                    if chase.type_and_var == null:
                         assert(types_to_do != [])
                         let nice_types = types_to_do
                         types_to_do = []
                     else:
-                        let varname = (chase.type_and_name as not null).name
-                        let case_type = self.get_type((chase.type_and_name as not null).type)
+                        let var = (chase.type_and_var as not null).var
+                        let case_type = self.get_type((chase.type_and_var as not null).type)
 
                         nice_types = get_type_members(case_type)
                         foreach t of nice_types:
@@ -833,15 +833,15 @@ class FunctionOrMethodConverter(
 
                         cases.push_all(case_code)
                         # TODO: error
-                        assert(not self.variables.has_key(varname))
-                        self.variables.set(varname, case_var)
+                        assert(not self.variables.has_key(var.name))
+                        self.variables.set(var.name, case_var)
 
                     cases.push_all(self.do_block(chase.body))
                     cases.push(new ir::GotoIf(done_label, self.bool_constant("true", chase.location)))
 
-                    if chase.type_and_name != null:
-                        assert(self.variables.get(varname) == case_var)
-                        self.variables.delete(varname)
+                    if chase.type_and_var != null:
+                        assert(self.variables.get(var.name) == case_var)
+                        self.variables.delete(var.name)
 
                     foreach type of nice_types:
                         self.code.push(new ir::UnionMemberCheck(member_check, union_var, type))
@@ -1152,10 +1152,9 @@ class FileConverter(
 
                 foreach method_def of classdef.body:
                     let self_location = classdef.location   # a bit weird
-                    method_def.args.insert(0, new ast::TypeAndName(
+                    method_def.args.insert(0, new ast::TypeAndVar(
                         new ast::NamedType(self_location, classtype.name),
-                        "self",
-                        self_location
+                        new ast::Variable(self_location, "self"),
                     ))
                     self.func_or_meth_step3(method_def, classtype)
 
@@ -1183,8 +1182,8 @@ class FileConverter(
         let local_var_counter = 0
         assert(def.args.length() == functype.argtypes.length())
         for let i = 0; i < def.args.length(); i = i+1:   # TODO: zip
-            let argname = def.args.get(i).name
-            let arg_location = def.args.get(i).name_location
+            let argname = def.args.get(i).var.name
+            let arg_location = def.args.get(i).var.location
             let type = functype.argtypes.get(i)
 
             local_var_counter = local_var_counter + 1

--- a/self_hosted/ast_transformer.oomph
+++ b/self_hosted/ast_transformer.oomph
@@ -1,28 +1,30 @@
 import "ast.oomph" as ast
+import "location.oomph" as location
+typedef Location = location::Location
 
 
 class AstTransformer(Int varname_counter):
 
-    meth get_var_name() -> Str:
+    meth get_var(Location location) -> ast::Variable:
         self.varname_counter = self.varname_counter + 1
         # Actally using this variable name would be invalid syntax, which is great
-        return "<var{self.varname_counter}>"
+        return new ast::Variable(location, "<var{self.varname_counter}>")
 
     meth foreach_loop_to_for_loop(ast::Loop loop) -> ast::Loop:
         let header = loop.loop_header as ast::ForeachLoopHeader
         let loc = header.keyword_location
 
-        let list_var = self.get_var_name()
-        let index_var = self.get_var_name()
+        let list_var = self.get_var(loc)
+        let index_var = self.get_var(loc)
 
         let body = [
             new ast::Let(
                 loc,
-                header.varname,
+                header.var,
                 new ast::Call(
                     loc,
-                    new ast::GetAttribute(loc, new ast::GetVar(loc, list_var), "get"),
-                    [new ast::GetVar(loc, index_var) as ast::Expression],
+                    new ast::GetAttribute(loc, new ast::GetVar(list_var), "get"),
+                    [new ast::GetVar(index_var) as ast::Expression],
                 ),
             ) as ast::Statement
         ]
@@ -37,9 +39,9 @@ class AstTransformer(Int varname_counter):
                 ],
                 new ast::BinaryOperator(
                     loc,
-                    new ast::GetVar(loc, index_var),
+                    new ast::GetVar(index_var),
                     "<",
-                    new ast::Call(loc, new ast::GetAttribute(loc, new ast::GetVar(loc, list_var), "length"), []),
+                    new ast::Call(loc, new ast::GetAttribute(loc, new ast::GetVar(list_var), "length"), []),
                 ),
                 [
                     new ast::SetVar(
@@ -47,7 +49,7 @@ class AstTransformer(Int varname_counter):
                         index_var,
                         new ast::BinaryOperator(
                             loc,
-                            new ast::GetVar(loc, index_var),
+                            new ast::GetVar(index_var),
                             "+",
                             new ast::IntConstant(loc, 1),
                         ),
@@ -59,7 +61,7 @@ class AstTransformer(Int varname_counter):
 
     meth handle_listcomp(ast::ListComprehension listcomp) -> ast::Expression:
         let loc = ast::locate_loop_header(listcomp.loop_header)
-        let var = self.get_var_name()
+        let var = self.get_var(loc)
         return self.visit_expression(new ast::StatementsAndExpression(
             loc,
             [
@@ -69,13 +71,13 @@ class AstTransformer(Int varname_counter):
                     [
                         new ast::Call(
                             loc,
-                            new ast::GetAttribute(loc, new ast::GetVar(loc, var), "push"),
+                            new ast::GetAttribute(loc, new ast::GetVar(var), "push"),
                             [listcomp.value],
                         ) as ast::Statement
                     ],
                 ) as ast::Statement,
             ],
-            new ast::GetVar(loc, var),
+            new ast::GetVar(var),
         ))
 
     meth visit_expression(ast::Expression expr) -> ast::Expression:

--- a/self_hosted/ast_transformer.oomph
+++ b/self_hosted/ast_transformer.oomph
@@ -23,8 +23,8 @@ class AstTransformer(Int varname_counter):
                 header.var,
                 new ast::Call(
                     loc,
-                    new ast::GetAttribute(loc, new ast::GetVar(list_var), "get"),
-                    [new ast::GetVar(index_var) as ast::Expression],
+                    new ast::GetAttribute(loc, list_var, "get"),
+                    [index_var as ast::Expression],
                 ),
             ) as ast::Statement
         ]
@@ -39,20 +39,15 @@ class AstTransformer(Int varname_counter):
                 ],
                 new ast::BinaryOperator(
                     loc,
-                    new ast::GetVar(index_var),
+                    index_var,
                     "<",
-                    new ast::Call(loc, new ast::GetAttribute(loc, new ast::GetVar(list_var), "length"), []),
+                    new ast::Call(loc, new ast::GetAttribute(loc, list_var, "length"), []),
                 ),
                 [
                     new ast::SetVar(
                         loc,
                         index_var,
-                        new ast::BinaryOperator(
-                            loc,
-                            new ast::GetVar(index_var),
-                            "+",
-                            new ast::IntConstant(loc, 1),
-                        ),
+                        new ast::BinaryOperator(loc, index_var, "+", new ast::IntConstant(loc, 1)),
                     ) as ast::Statement
                 ],
             ),
@@ -71,13 +66,13 @@ class AstTransformer(Int varname_counter):
                     [
                         new ast::Call(
                             loc,
-                            new ast::GetAttribute(loc, new ast::GetVar(var), "push"),
+                            new ast::GetAttribute(loc, var, "push"),
                             [listcomp.value],
                         ) as ast::Statement
                     ],
                 ) as ast::Statement,
             ],
-            new ast::GetVar(var),
+            var,
         ))
 
     meth visit_expression(ast::Expression expr) -> ast::Expression:
@@ -96,7 +91,7 @@ class AstTransformer(Int varname_counter):
                 pass
             case ast::GetAttribute getattr:
                 getattr.obj = self.visit_expression(getattr.obj)
-            case ast::GetVar _:
+            case ast::Variable _:
                 pass
             case ast::IntConstant _:
                 pass

--- a/self_hosted/parser.oomph
+++ b/self_hosted/parser.oomph
@@ -217,7 +217,7 @@ class Parser(List[tokenizer::Token] tokens):
 
         elif self.peek().type == "id":
             let token = self.get_token_by_type("id")
-            result = new ast::GetVar(new ast::Variable(token.location, token.value))
+            result = new ast::Variable(token.location, token.value)
 
         elif self.peek().type == "int":
             let token = self.get_token_by_type("int")
@@ -488,8 +488,8 @@ class Parser(List[tokenizer::Token] tokens):
             let equals = self.get_token("op", "=")
             value = self.parse_expression(null)
             switch expr:
-                case ast::GetVar getvar:
-                    return new ast::SetVar(equals.location, getvar.var, value)
+                case ast::Variable variable:
+                    return new ast::SetVar(equals.location, variable, value)
                 case ast::GetAttribute getattr:
                     return new ast::SetAttribute(equals.location, getattr.obj, getattr.attribute, value)
                 case *:

--- a/self_hosted/parser.oomph
+++ b/self_hosted/parser.oomph
@@ -95,6 +95,19 @@ class Parser(List[tokenizer::Token] tokens):
         self.get_token("op", ")")
         return result
 
+    meth parse_commasep_types_and_vars_in_parens() -> List[ast::TypeAndVar]:
+        self.get_token("op", "(")
+        let result = []
+        if not self.peek().matches("op", ")"):
+            result.push(self.parse_type_and_var())
+            while self.peek().matches("op", ","):
+                self.get_token("op", ",")
+                if self.peek().matches("op", ")"):
+                    break
+                result.push(self.parse_type_and_var())
+        self.get_token("op", ")")
+        return result
+
     # Weirdly returns location, can't easily return 2 values yet
     meth parse_one_or_more_commasep_types_in_square_brackets(List[ast::Type] result) -> Location:
         let start = self.get_token("op", "[")
@@ -204,7 +217,7 @@ class Parser(List[tokenizer::Token] tokens):
 
         elif self.peek().type == "id":
             let token = self.get_token_by_type("id")
-            result = new ast::GetVar(token.location, token.value)
+            result = new ast::GetVar(new ast::Variable(token.location, token.value))
 
         elif self.peek().type == "int":
             let token = self.get_token_by_type("int")
@@ -445,10 +458,12 @@ class Parser(List[tokenizer::Token] tokens):
     meth parse_oneline_ish_statement() -> ast::Statement:
         if self.peek().matches("keyword", "let"):
             let leet = self.get_token("keyword", "let")
-            let varname = self.get_token_by_type("id").value
+            let var = self.get_token_by_type("id")
             self.get_token("op", "=")
             let value = self.parse_expression(null)
-            return new ast::Let(leet.location, varname, value)
+            return new ast::Let(
+                leet.location, new ast::Variable(var.location, var.value), value
+            )
 
         if self.peek().matches("keyword", "return"):
             let ret = self.get_token("keyword", "return")
@@ -474,7 +489,7 @@ class Parser(List[tokenizer::Token] tokens):
             value = self.parse_expression(null)
             switch expr:
                 case ast::GetVar getvar:
-                    return new ast::SetVar(equals.location, getvar.varname, value)
+                    return new ast::SetVar(equals.location, getvar.var, value)
                 case ast::GetAttribute getattr:
                     return new ast::SetAttribute(equals.location, getattr.obj, getattr.attribute, value)
                 case *:
@@ -487,9 +502,9 @@ class Parser(List[tokenizer::Token] tokens):
         let case_keyword = self.get_token("keyword", "case")
         if self.peek().matches("op", "*"):
             self.get_token("op", "*")
-            let type_and_varname = null as ast::TypeAndName | null
+            let type_and_varname = null as ast::TypeAndVar | null
         else:
-            type_and_varname = self.parse_type_and_name()
+            type_and_varname = self.parse_type_and_var()
         let body = self.parse_block_of_statements()
         return new ast::Case(case_keyword.location, type_and_varname, body)
 
@@ -522,9 +537,11 @@ class Parser(List[tokenizer::Token] tokens):
 
         if self.peek().matches("keyword", "foreach"):
             let location = self.get_token("keyword", "foreach").location
-            let varname = self.get_token_by_type("id").value
+            let var = self.get_token_by_type("id")
             self.get_token("keyword", "of")
-            return new ast::ForeachLoopHeader(location, varname, self.parse_expression(null))
+            return new ast::ForeachLoopHeader(
+                location, new ast::Variable(var.location, var.value), self.parse_expression(null)
+            )
 
         assert(false)
 
@@ -591,14 +608,20 @@ class Parser(List[tokenizer::Token] tokens):
             result.push(self.parse_type_without_unions())
         return new ast::UnionType(result)
 
+    # TODO: parse_type_and_var, parse_type_and_name: both needed?
+    meth parse_type_and_var() -> ast::TypeAndVar:
+        let type = self.parse_type()
+        let arg = self.get_token_by_type("id")
+        return new ast::TypeAndVar(type, new ast::Variable(arg.location, arg.value))
+
     meth parse_type_and_name() -> ast::TypeAndName:
         let type = self.parse_type()
         let arg = self.get_token_by_type("id")
-        return new ast::TypeAndName(type, arg.value, arg.location)
+        return new ast::TypeAndName(type, arg.value)
 
     meth parse_function_or_method(Location func_or_meth_location) -> ast::FuncOrMethodDef:
-        let name = self.get_token_by_type("id").value
-        let args = self.parse_commasep_types_and_names_in_parens()
+        let name = self.get_token_by_type("id")
+        let args = self.parse_commasep_types_and_vars_in_parens()
 
         if self.peek().matches("op", "->"):
             self.get_token("op", "->")
@@ -613,7 +636,7 @@ class Parser(List[tokenizer::Token] tokens):
 
         return new ast::FuncOrMethodDef(
             func_or_meth_location,
-            name,
+            name.value,
             args,
             returntype,
             self.parse_block_of_statements()

--- a/self_hosted/parser.oomph
+++ b/self_hosted/parser.oomph
@@ -608,7 +608,6 @@ class Parser(List[tokenizer::Token] tokens):
             result.push(self.parse_type_without_unions())
         return new ast::UnionType(result)
 
-    # TODO: parse_type_and_var, parse_type_and_name: both needed?
     meth parse_type_and_var() -> ast::TypeAndVar:
         let type = self.parse_type()
         let arg = self.get_token_by_type("id")


### PR DESCRIPTION
will be useful for autotype rewrite, I'm planning a `Mapping` with variable refs as keys